### PR TITLE
Increase budget phase description max length

### DIFF
--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -3,7 +3,7 @@ class Budget
     PHASE_KINDS = %w[informing accepting reviewing selecting valuating publishing_prices balloting
                 reviewing_ballots finished].freeze
     PUBLISHED_PRICES_PHASES = %w[publishing_prices balloting reviewing_ballots finished].freeze
-    DESCRIPTION_MAX_LENGTH = 2000
+    DESCRIPTION_MAX_LENGTH = 4000
 
     translates :name, touch: true
     translates :summary, touch: true


### PR DESCRIPTION
## Objectives

Increase budget phase description max length from 2000 to 4000.
